### PR TITLE
make sure condor_reconfig is not run before service is up

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -277,8 +277,9 @@ class htcondor::config (
     }
   }
 
-  exec { '/usr/sbin/condor_reconfig':
-    subscribe   => $config_files,
-    refreshonly => true,
-  }
+  #this exec must be created in the service.pp file if we want to properly handle order including at first run, since the service must be started before the reconfig is done
+  #AND there is an upper Class order saying config must be done before starting service.
+  #$config_files is already a "File" resouce collection.
+  $config_files ~> Exec['/usr/sbin/condor_reconfig']
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,4 +8,9 @@ class htcondor::service {
     hasrestart => true,
     hasstatus  => true,
   }
+  ->
+  #this exec is called from the config, but we can't run it if the condor service is not up. it's a RE-config command assuming something is already up.
+  exec{ '/usr/sbin/condor_reconfig':
+    refreshonly => true,
+  }
 }


### PR DESCRIPTION
This makes sure the initial install will correctly handle the condor_reconfig, thus preventing the need for a 2nd puppet run to properly configure the machine - or this will just remove an installation error...
