### PR TITLE
enable cgroup

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -97,6 +97,7 @@ class htcondor::config (
   $computing_elements  = [],
   $condor_admin_email  = 'root@mysite.org',
   $custom_attribute    = 'NORDUGRID_QUEUE',
+  $enable_cgroup       = false,
   $enable_multicore    = false,
   $enable_healthcheck  = false,
   $high_priority_groups           = {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class htcondor (
   $condor_priority                = '99',
   $condor_version                 = 'present',
   $custom_attribute               = 'NORDUGRID_QUEUE',
+  $enable_cgroup                  = false,
   $enable_multicore               = false,
   $enable_healthcheck             = false,
   $high_priority_groups           = {
@@ -205,6 +206,7 @@ class htcondor (
     computing_elements             => $computing_elements,
     condor_admin_email             => $condor_admin_email,
     custom_attribute               => $custom_attribute,
+    enable_cgroup                  => $enable_cgroup,
     enable_multicore               => $enable_multicore,
     enable_healthcheck             => $enable_healthcheck,
     high_priority_groups           => $high_priority_groups,

--- a/templates/20_workernode.config.erb
+++ b/templates/20_workernode.config.erb
@@ -6,6 +6,9 @@ NUM_CPUS = <%= @number_of_cpus %>
 <% else -%>
 NUM_CPUS = <%= @processorcount %>
 <% end -%>
+
+DETECTED_CPUS = $NUM_CPUS
+
 # custom attribute for easier splitting into queues
 # with ARC CE (using condor_requirements=" && custom_attribute"
 <%= @custom_attribute %> = True

--- a/templates/20_workernode.config.erb
+++ b/templates/20_workernode.config.erb
@@ -84,6 +84,12 @@ MAX_NUM_MASTER_LOG = 10
 MAX_STARTD_LOG = 104857600
 MAX_NUM_STARTD_LOG = 10
 
+<%- if @enable_cgroup -%>
+# Enable CGROUP
+BASE_CGROUP = htcondor
+CGROUP_MEMORY_LIMIT = soft
+<%- end -%>
+
 ## Debugging
 #STARTD_DEBUG = D_COMMAND D_FULLDEBUG
 


### PR DESCRIPTION
Enable cgroup in condor config. It is false by default. It does not setup cgroup for the machine.
Added DETECTED_CPU in WN template