### PR TITLE
htcondor::sharedport: Add configuration for condor_shared_port daemon.

### DIFF
--- a/manifests/config/sharedport.pp
+++ b/manifests/config/sharedport.pp
@@ -1,0 +1,25 @@
+# Configuration of Condor SharedPort service
+class htcondor::config::sharedport {
+  $use_shared_port            = $htcondor::use_shared_port
+  $shared_port                = $htcondor::shared_port
+  $shared_port_collector_name = $htcondor::shared_port_collector_name
+
+  $template_sharedport        = $htcondor::template_sharedport
+  $managers                   = $htcondor::managers
+
+  $condor_user                = $htcondor::condor_user
+  $condor_group               = $htcondor::condor_group
+
+  $now                        = strftime('%d.%m.%Y_%H.%M')
+
+  # SharedPort service configuration
+  file { '/etc/condor/config.d/42_shared_port.config':
+    backup  => ".bak.${now}",
+    content => template($template_sharedport),
+    require => Package['condor'],
+    owner   => $condor_user,
+    group   => $condor_group,
+    mode    => '0644',
+    notify  => Exec['/usr/sbin/condor_reconfig'],
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,6 +167,7 @@ class htcondor (
   $template_ganglia               = $htcondor::params::template_ganglia,
   $template_workernode            = $htcondor::params::template_workernode,
   $template_defrag                = $htcondor::params::template_defrag,
+  $template_sharedport            = $htcondor::params::template_sharedport,
   $template_highavailability      =
   $htcondor::params::template_highavailability,
   $use_htcondor_account_mapping   =
@@ -186,7 +187,10 @@ class htcondor (
   $machine_list_prefix            = $htcondor::params::machine_list_prefix,
   $max_walltime                   = $htcondor::params::max_walltime,
   $max_cputime                    = $htcondor::params::max_cputime,
-  $memory_factor                  = $htcondor::paramse::memory_factor,) inherits
+  $memory_factor                  = $htcondor::paramse::memory_factor,
+  $use_shared_port                = $htcondor::use_shared_port,
+  $shared_port                    = $htcondor::shared_port,
+  $shared_port_collector_name     = $htcondor::shared_port_collector_name,) inherits
 ::htcondor::params {
   if $install_repositories {
     class { 'htcondor::repositories': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -122,6 +122,11 @@ class htcondor::params {
   $uses_connection_broker         = hiera('uses_connection_broker', false)
   $private_network_name           = hiera('private_network_name', $::domain)
 
+  # SharedPort service configuration
+  $use_shared_port                = hiera('use_shared_port', false)
+  $shared_port                    = hiera('shared_port', 9618)
+  $shared_port_collector_name     = hiera('shared_port_collector_name', 'collector')
+
   # notification settings
   $admin_email                    = hiera('admin_email', 'localhost')
   $email_domain                   = hiera('email_domain', 'localhost')
@@ -147,5 +152,7 @@ class htcondor::params {
   $template_defrag                = hiera('template_defrag', "${module_name}/33_defrag.config.erb"
   )
   $template_highavailability      = hiera('template_defrag', "${module_name}/30_highavailability.config.erb"
+  )
+  $template_sharedport            = hiera('template_sharedport', "${module_name}/42_shared_port.config.erb"
   )
 }

--- a/templates/42_shared_port.config.erb
+++ b/templates/42_shared_port.config.erb
@@ -1,0 +1,4 @@
+SHARED_PORT_ARGS = -p <%= @shared_port %>
+DAEMON_LIST = $(DAEMON_LIST), SHARED_PORT
+COLLECTOR_HOST = <%= @managers.flatten.join("?sock=@shared_port_collector_name, ") %>?sock=<%= @shared_port_collector_name %>
+USE_SHARED_PORT = <%= @use_shared_port %>


### PR DESCRIPTION
Extremely useful in firewalled environments, off by default. 