### PR TITLE
htcondor::security Pull CERTIFICATE_MAPFILE out of krb-auth dependency.

### DIFF
--- a/manifests/config/security.pp
+++ b/manifests/config/security.pp
@@ -86,16 +86,16 @@ class htcondor::config::security {
     }
   }
 
-  if $use_kerberos_auth {
-    if $use_cert_map_file {
-      file { $cert_map_file:
-        ensure => present,
-        source => $cert_map_file_source,
-        owner  => $condor_user,
-        group  => $condor_group,
-      }
+  if $use_cert_map_file {
+    file { $cert_map_file:
+      ensure => present,
+      source => $cert_map_file_source,
+      owner  => $condor_user,
+      group  => $condor_group,
     }
+  }
 
+  if $use_kerberos_auth {
     if $use_krb_map_file {
       file { $krb_map_file:
         ensure => present,

--- a/templates/10_security.config.erb
+++ b/templates/10_security.config.erb
@@ -87,12 +87,12 @@ SEC_READ_AUTHENTICATION_METHODS = <%= @auth_string %>
 SCHEDD.SEC_WRITE_AUTHENTICATION_METHODS = <%= @auth_string %>
 SCHEDD.SEC_DAEMON_AUTHENTICATION_METHODS = <%= @auth_string %>
 
-<% if @use_kerberos_auth then -%>
-SEC_ENABLE_MATCH_PASSWORD_AUTHENTICATION = True
-<% if @use_cert_map_file -%>
+<% if @use_cert_map_file then -%>
 CERTIFICATE_MAPFILE = <%= @cert_map_file %>
 <% end -%>
-<% if @use_krb_map_file -%>
+<% if @use_kerberos_auth then -%>
+SEC_ENABLE_MATCH_PASSWORD_AUTHENTICATION = True
+<% if @use_krb_map_file then -%>
 KERBEROS_MAP_FILE = <%= @krb_map_file %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
The CERTIFICATE_MAPFILE is a "unified mapfile" (htcondor documentation term) used for all authentication
methods. 

It is not at all specific to Kerberos alone, but also treats SSL, FS etc. 