### PR TITLE
Allow to turn off debug notification.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class htcondor::config {
   $is_worker            = $htcondor::is_worker
   $managers             = $htcondor::managers
   $use_shared_port      = $htcondor::use_shared_port
+  $use_debug_notify     = $htcondor::use_debug_notify
 
   # purge all non-managed config files from /etc/condor/config.d
   file { '/etc/condor/config.d':
@@ -28,17 +29,19 @@ class htcondor::config {
   $daemon_list            = create_daemon_list($is_worker, $is_scheduler,
   $is_manager, $enable_multicore, $run_ganglia, $more_than_two_managers)
 
-  $debug_msg = "constructing daemon list from \n \
-                -is_worker: ${is_worker}\n \
-                -is_scheduler: ${is_scheduler}\n \
-                -is_manager: ${is_manager}\n \
-                -enable_multicore: ${enable_multicore}\n \
-                -run_ganglia: ${run_ganglia} \n \
-                -more_than_two_managers: ${more_than_two_managers} \n\
-                resulting in ${daemon_list}"
-  notify { 'checking daemon list:':
-    withpath => true,
-    name     => $debug_msg,
+  if $use_debug_notify {
+    $debug_msg = "constructing daemon list from \n \
+                  -is_worker: ${is_worker}\n \
+                  -is_scheduler: ${is_scheduler}\n \
+                  -is_manager: ${is_manager}\n \
+                  -enable_multicore: ${enable_multicore}\n \
+                  -run_ganglia: ${run_ganglia} \n \
+                  -more_than_two_managers: ${more_than_two_managers} \n\
+                  resulting in ${daemon_list}"
+    notify { 'checking daemon list:':
+      withpath => true,
+      name     => $debug_msg,
+    }
   }
 
   if $use_shared_port {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,7 @@ class htcondor (
   $condor_version                 = $htcondor::params::condor_version,
   $custom_machine_attributes      = $htcondor::params::custom_machine_attributes,
   $custom_job_attributes          = $htcondor::params::custom_job_attributes,
+  $use_debug_notify               = $htcondor::params::use_debug_notify,
   $enable_condor_reporting        = $htcondor::params::enable_condor_reporting,
   $enable_cgroup                  = $htcondor::params::enable_cgroup,
   $enable_multicore               = $htcondor::params::enable_multicore,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,8 @@ class htcondor::params {
   $custom_machine_attributes      = hiera_hash('custom_machine_attribute', {})
   $custom_job_attributes          = hiera_hash('custom_job_attributes', {})
 
+  $use_debug_notify               = hiera('use_debug_notify', true)
+
   # this is one of the funding requirements for HTCondor
   # for more information see https://research.cs.wisc.edu/htcondor/privacy.html
   $enable_condor_reporting        = hiera('enable_condor_reporting', true)


### PR DESCRIPTION
The notification does not play well with monitoring
such as the one provided by foreman,
since the machine will always be shown as "performed changes",
since puppet produced output.

This change allows to turn it off, but still leaves it on by default. 