### PR TITLE
Remove bad quotes from MOUNT_UNDER_SCRATCH variable.

### DIFF
--- a/templates/20_workernode.config.erb
+++ b/templates/20_workernode.config.erb
@@ -87,7 +87,7 @@ EXECUTE = <%= @pool_home %>/condor
 
 ## Writable scratch directories bind mounted in scratch, e.g. for docker / singularity containers. 
 ## Auto-deleted after the job exits.
-MOUNT_UNDER_SCRATCH = "<%= @mount_under_scratch_dirs.flatten.join(", ") %>"
+MOUNT_UNDER_SCRATCH = <%= @mount_under_scratch_dirs.flatten.join(", ") %>
 
 ## Make sure jobs have independent PID namespaces
 <% if @use_pid_namespaces -%>


### PR DESCRIPTION
This is not an expression, so the additional quotes are interpreted
as actual part of the path.

Sorry, my fault! 