### PR TITLE
Add starter environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ force_singularity_jobs   => true,
 singularity_image_expr   => "/images/myimage.img",
 singularity_bind_paths   => ['/some_shared_filesystem', '/pool', '/usr/libexec/condor/'],
 singularity_target_dir   => '/srv',
+starter_job_environment  => { 'SINGULARITY_HOME' => '/srv' },
 mount_under_scratch_dirs => ['/tmp','/var/tmp'],
 ```
 This forces all jobs to run inside Singularity containers, while offering `tmp` space inside the container, and binding a shared filesystem mount point and HTCondor-specific directories inside.
 The binding of the two HTCondor specific directories is a workaround to allow interactive jobs to run, this will hopefully be fixed in a future HTCondor release.
+The same holds for setting `SINGULARITY_HOME`: This ensures non-interactive jobs start in the job's working directory instead of the user's home directory which might not even be accessible from the worker.
 
 The Image may also be an expression to allow for user configuration, more details on that are provided in the [HTCondor documentation](https://research.cs.wisc.edu/htcondor/manual/latest/3_17Singularity_Support.html).
 

--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -17,6 +17,7 @@ class htcondor::config::worker {
   $memory_overcommit         = $htcondor::memory_overcommit
   $number_of_cpus            = $htcondor::number_of_cpus
   $partitionable_slots       = $htcondor::partitionable_slots
+  $starter_job_environment   = $htcondor::starter_job_environment
   $pool_create               = $htcondor::pool_create
   $pool_home                 = $htcondor::pool_home
   $use_pid_namespaces        = $htcondor::use_pid_namespaces

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,6 +137,7 @@ class htcondor (
   $request_memory                 = $htcondor::params::request_memory,
   $certificate_mapfile            = $htcondor::params::certificate_mapfile,
   $kerberos_mapfile               = $htcondor::params::kerberos_mapfile,
+  $starter_job_environment        = $htcondor::params::starter_job_environment,
   $pool_home                      = $htcondor::params::pool_home,
   $pool_create                    = $htcondor::params::pool_create,
   $mount_under_scratch_dirs       = $htcondor::params::mount_under_scratch_dirs,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,7 @@ class htcondor::params {
   $memory_overcommit              = hiera('memory_overcommit', 1.5)
   $request_memory                 = hiera('request_memory', true)
 
+  $starter_job_environment        = hiera_hash('starter_job_environment', {})
   $pool_home                      = hiera('pool_home', '/pool')
   $pool_create                    = hiera('pool_create', true)
   $mount_under_scratch_dirs       = hiera_array('mount_under_scratch_dirs', ['/tmp', '/var/tmp'])

--- a/templates/20_workernode.config.erb
+++ b/templates/20_workernode.config.erb
@@ -82,6 +82,9 @@ MAXJOBRETIREMENTTIME = $(HOUR) * 24 * 3
 UPDATE_INTERVAL = $RANDOM_INTEGER(230, 370)
 MASTER_UPDATE_INTERVAL = $RANDOM_INTEGER(230, 370)
 
+## Special environment setup
+STARTER_JOB_ENVIRONMENT = "<%= @starter_job_environment.map{|e| e.join('=')}.join(" ") %>"
+
 ## Location of scratch directories
 EXECUTE = <%= @pool_home %>/condor
 


### PR DESCRIPTION
This allows to pass on environment seen by the
user's jobs, and also e.g. by the executed singularity
container.
It is especially helpful with singularity, since HTCondor does not (yet) take care of passing an appropriate home-directory to the container instance. 