### PR TITLE
Setting of correct SELinux context for pool directory if we create it.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,6 +136,7 @@ class htcondor (
   $memory_overcommit              = $htcondor::params::memory_overcommit,
   $request_memory                 = $htcondor::params::request_memory,
   $starter_job_environment        = $htcondor::params::starter_job_environment,
+  $manage_selinux                 = $htcondor::params::manage_selinux,
   $pool_home                      = $htcondor::params::pool_home,
   $pool_create                    = $htcondor::params::pool_create,
   $mount_under_scratch_dirs       = $htcondor::params::mount_under_scratch_dirs,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,6 +73,7 @@ class htcondor::params {
   $request_memory                 = hiera('request_memory', true)
 
   $starter_job_environment        = hiera_hash('starter_job_environment', {})
+  $manage_selinux                 = hiera('manage_selinux', true)
   $pool_home                      = hiera('pool_home', '/pool')
   $pool_create                    = hiera('pool_create', true)
   $mount_under_scratch_dirs       = hiera_array('mount_under_scratch_dirs', ['/tmp', '/var/tmp'])

--- a/metadata.json
+++ b/metadata.json
@@ -34,6 +34,9 @@
     }
   ],
   "dependencies": [
-
+    {
+       "name": "puppet/selinux",
+       "version_requirement": "1.x.x",
+    }
   ]
 }


### PR DESCRIPTION
Can be enabled / disabled with manage_selinux flag, default on (since SELinux is default on on all supported OS of this module). 

This requires `puppet/selinux` (from Voxpopuli) and fixes interactive jobs etc. if SELinux is activated,
since HTCondor installs SELinux rules for all that bound to the `condor_var_lib_t` type. 