### PR TITLE
Central manager HA with shared port

### DIFF
--- a/manifests/config/sharedport.pp
+++ b/manifests/config/sharedport.pp
@@ -13,7 +13,7 @@ class htcondor::config::sharedport {
   $now                        = strftime('%d.%m.%Y_%H.%M')
 
   # SharedPort service configuration
-  file { '/etc/condor/config.d/42_shared_port.config':
+  file { '/etc/condor/config.d/27_shared_port.config':
     backup  => ".bak.${now}",
     content => template($template_sharedport),
     require => Package['condor'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -174,7 +174,7 @@ class htcondor::params {
   )
   $template_highavailability      = hiera('template_defrag', "${module_name}/30_highavailability.config.erb"
   )
-  $template_sharedport            = hiera('template_sharedport', "${module_name}/42_shared_port.config.erb"
+  $template_sharedport            = hiera('template_sharedport', "${module_name}/27_shared_port.config.erb"
   )
   $template_singularity           = hiera('template_singularity', "${module_name}/50_singularity.config.erb"
   )

--- a/templates/27_shared_port.config.erb
+++ b/templates/27_shared_port.config.erb
@@ -1,4 +1,5 @@
-SHARED_PORT_ARGS = -p <%= @shared_port %>
+SHARED_PORT_PORT = <%= @shared_port %>
+SHARED_PORT_ARGS = -p $(SHARED_PORT_PORT)
 DAEMON_LIST = $(DAEMON_LIST), SHARED_PORT
 COLLECTOR_HOST = <%= @managers.flatten.join("?sock=" + @shared_port_collector_name + ", ") %>?sock=<%= @shared_port_collector_name %>
 USE_SHARED_PORT = <%= @use_shared_port %>

--- a/templates/30_highavailability.config.erb
+++ b/templates/30_highavailability.config.erb
@@ -5,16 +5,27 @@
 ## for when defining HAD_LIST.  This port number is
 ## arbitrary; make sure that there is no port number collision
 ## with other applications.
+<% use_shared_port = scope.lookupvar('::htcondor::use_shared_port') -%>
+<% if use_shared_port -%>
+HAD_PORT = $(SHARED_PORT_PORT)
+HAD_USE_SHARED_PORT = TRUE
+<% else -%>
 HAD_PORT = 51450
 HAD_ARGS = -p $(HAD_PORT)
+<% end -%>
 
 ## The following macro defines the port number condor_replication will listen
 ## on on this machine. This port should match the port number specified
 ## for that replication daemon in the REPLICATION_LIST
 ## Port number is arbitrary (make sure no collision with other applications)
 ## This is a sample port number
+<% if use_shared_port -%>
+REPLICATION_PORT = $(SHARED_PORT_PORT)
+REPLICATION_USE_SHARED_PORT = TRUE
+<% else -%>
 REPLICATION_PORT = 41450
 REPLICATION_ARGS = -p $(REPLICATION_PORT)
+<% end -%>
 
 ## The following list must contain the same addresses
 ## as HAD_LIST. In addition, for each hostname, it should specify 

--- a/templates/42_shared_port.config.erb
+++ b/templates/42_shared_port.config.erb
@@ -1,4 +1,4 @@
 SHARED_PORT_ARGS = -p <%= @shared_port %>
 DAEMON_LIST = $(DAEMON_LIST), SHARED_PORT
-COLLECTOR_HOST = <%= @managers.flatten.join("?sock=@shared_port_collector_name, ") %>?sock=<%= @shared_port_collector_name %>
+COLLECTOR_HOST = <%= @managers.flatten.join("?sock=" + @shared_port_collector_name + ", ") %>?sock=<%= @shared_port_collector_name %>
 USE_SHARED_PORT = <%= @use_shared_port %>


### PR DESCRIPTION
This patch allows that the had and replication daemons (for central manager HA) use the shared port daemon.