### PR TITLE
Add parameters gpgcheck and gpgkey

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,12 @@
 # [*install_repositories*]
 # Bool to install repositories or not
 #
+# [*gpgcheck*]
+# Boolean to specify whether the GPG signature of the packages should be checked
+#
+# [*gpgkey*]
+# URL of the GPG key used to sign the packages
+#
 # [*$is_scheduler*]
 # If current machine is a condor scheduler
 #
@@ -125,6 +131,8 @@ class htcondor (
   $include_username_in_accounting =
   $htcondor::params::include_username_in_accounting,
   $install_repositories           = $htcondor::params::install_repositories,
+  $gpgcheck                       = $htcondor::params::gpgcheck,
+  $gpgkey                         = $htcondor::params::gpgkey,
   $dev_repositories               = $htcondor::params::dev_repositories,
   $is_scheduler                   = $htcondor::params::is_scheduler,
   $is_manager                     = $htcondor::params::is_manager,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,6 +61,8 @@ class htcondor::params {
   $include_username_in_accounting = hiera('include_username_in_accounting',
   false)
   $install_repositories           = hiera('install_repositories', true)
+  $gpgcheck                       = hiera('gpgcheck', true)
+  $gpgkey                         = hiera('gpgkey', 'http://htcondor.org/yum/RPM-GPG-KEY-HTCondor')
   $dev_repositories               = hiera('dev_repositories', false)
 
   $machine_owner                  = hiera('machine_owner', 'physics')

--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -3,6 +3,8 @@
 # Provides yum repositories for HTCondor installation
 class htcondor::repositories {
   $dev_repos       = $htcondor::dev_repositories
+  $gpgcheck        = $htcondor::gpgcheck
+  $gpgkey          = $htcondor::gpgkey
   $condor_priority = $htcondor::condor_priority
   $major_release   = regsubst($::operatingsystemrelease, '^(\d+)\.\d+$', '\1')
 
@@ -13,7 +15,8 @@ class htcondor::repositories {
           descr    => "HTCondor Development RPM Repository for Redhat Enterprise Linux ${facts['os']['release']['major']}",
           baseurl  => 'http://research.cs.wisc.edu/htcondor/yum/development/rhel$releasever',
           enabled  => 1,
-          gpgcheck => 0,
+          gpgcheck => bool2num($gpgcheck),
+          gpgkey   => $gpgkey,
           priority => $condor_priority,
           exclude  => 'condor.i386, condor.i686',
           before   => [Package['condor']],
@@ -23,7 +26,8 @@ class htcondor::repositories {
           descr    => "HTCondor Stable RPM Repository for Redhat Enterprise Linux ${facts['os']['release']['major']}",
           baseurl  => 'http://research.cs.wisc.edu/htcondor/yum/stable/rhel$releasever',
           enabled  => 1,
-          gpgcheck => 0,
+          gpgcheck => bool2num($gpgcheck),
+          gpgkey   => $gpgkey,
           priority => $condor_priority,
           exclude  => 'condor.i386, condor.i686',
           before   => [Package['condor']],


### PR DESCRIPTION
By default the GPG signature of packages installed from the HTCondor stable and development repositories is checked now.