### PR TITLE
Remove MOUNT_UNDER_SCRATCH if no folders are defined

### DIFF
--- a/templates/20_workernode.config.erb
+++ b/templates/20_workernode.config.erb
@@ -88,9 +88,11 @@ STARTER_JOB_ENVIRONMENT = "<%= @starter_job_environment.map{|e| e.join('=')}.joi
 ## Location of scratch directories
 EXECUTE = <%= @pool_home %>/condor
 
-## Writable scratch directories bind mounted in scratch, e.g. for docker / singularity containers. 
+<% if @mount_under_scratch_dirs.any? -%>
+## Writable scratch directories bind mounted in scratch, e.g. for docker / singularity containers.
 ## Auto-deleted after the job exits.
 MOUNT_UNDER_SCRATCH = <%= @mount_under_scratch_dirs.flatten.join(", ") %>
+<% end -%>
 
 ## Make sure jobs have independent PID namespaces
 <% if @use_pid_namespaces -%>


### PR DESCRIPTION
Since `MOUNT_UNDER_SCRATCH` can be problematic if payload jobs do not have write access, I've added two lines to the worker template to remove the config value if the parameter is set to an empty list (e.g. `htcondor::mount_under_scratch_dirs: []`)