### PR TITLE
Fixing permissions for worker healthcheck script (issue #77)

### DIFF
--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -58,7 +58,7 @@ class htcondor::config::worker {
     source => $health_check_script,
     owner  => $condor_user,
     group  => $condor_group,
-    mode   => '0655',
+    mode   => '0755',
   }
 
   if $pool_create {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -83,7 +83,7 @@ class htcondor::params {
   $periodic_expr_interval         = hiera('periodic_expr_interval', 60)
   $max_periodic_expr_interval     = hiera('max_periodic_expr_interval', 1200)
   $remove_held_jobs_after         = hiera('remove_held_jobs_after', 1200)
-  $leave_job_in_queue             = hiera('leave_job_in_queue', undef)
+  $leave_job_in_queue             = hiera('leave_job_in_queue', false)
   $max_walltime                   = hiera('max_walltime', '80 * 60 * 60')
   $max_cputime                    = hiera('max_cputime', '80 * 60 * 60')
   $memory_factor                  = hiera('memory_factor', '1000')


### PR DESCRIPTION
Importing two fixes from @afortiorama's fork:
 - fixing issue #77 
 - better default for `leave_job_in_queue` 