### PR TITLE
Fixing invalid SINGULARITY_IMAGE_EXPR by adding missing double-quotes

### DIFF
--- a/templates/50_singularity.config.erb
+++ b/templates/50_singularity.config.erb
@@ -5,11 +5,10 @@ SINGULARITY = <%= @singularity_path %>
 SINGULARITY_JOB = <%= @force_singularity_jobs %>
 
 # Forces all jobs to use the given image.
-SINGULARITY_IMAGE_EXPR = <%= @singularity_image_expr %>
+SINGULARITY_IMAGE_EXPR = "<%= @singularity_image_expr %>"
 
-# Paths to bind via user bind control. 
+# Paths to bind via user bind control.
 SINGULARITY_BIND_EXPR = "<%= @singularity_bind_paths.flatten.join(",") %>"
 
 # Maps $_CONDOR_SCRATCH_DIR on the host to given path inside the image.
 SINGULARITY_TARGET_DIR = <%= @singularity_target_dir %>
-


### PR DESCRIPTION
`SINGULARITY_IMAGE_EXPR` needs to be within double-quotes for HTCondor to parse it correctly

The current implementation causes the following error with condor `8.6.11`:
```
05/31/18 16:20:14 (pid:100974) Singularity support was requested but unable to determine the image to use.
05/31/18 16:20:14 (pid:100974) Singularity enabled but setup failed; failing job.
05/31/18 16:20:14 (pid:100974) Failed to start job, exiting
05/31/18 16:20:14 (pid:100974) ShutdownFast all jobs.
```