### PR TITLE
Queue super users

### DIFF
--- a/manifests/config/security.pp
+++ b/manifests/config/security.pp
@@ -16,6 +16,7 @@ class htcondor::config::security (
   $managers                     = $htcondor::managers
   $workers                      = $htcondor::workers
 
+  $queue_super_users            = $htcondor::queue_super_users
   $use_anonymous_auth           = $htcondor::use_anonymous_auth
   $use_fs_auth                  = $htcondor::use_fs_auth
   $use_password_auth            = $htcondor::use_password_auth

--- a/manifests/config/security.pp
+++ b/manifests/config/security.pp
@@ -17,6 +17,7 @@ class htcondor::config::security (
   $workers                      = $htcondor::workers
 
   $queue_super_users            = $htcondor::queue_super_users
+  $queue_super_user_impersonate = $htcondor::queue_super_user_impersonate
   $use_anonymous_auth           = $htcondor::use_anonymous_auth
   $use_fs_auth                  = $htcondor::use_fs_auth
   $use_password_auth            = $htcondor::use_password_auth

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,6 +187,7 @@ class htcondor (
   $htcondor::params::template_highavailability,
   $use_htcondor_account_mapping   =
   $htcondor::params::use_htcondor_account_mapping,
+  $queue_super_users              = $htcondor::params::queue_super_users,
   $use_anonymous_auth             = $htcondor::params::use_anonymous_auth,
   $use_fs_auth                    = $htcondor::params::use_fs_auth,
   $use_password_auth              = $htcondor::params::use_password_auth,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -188,6 +188,7 @@ class htcondor (
   $use_htcondor_account_mapping   =
   $htcondor::params::use_htcondor_account_mapping,
   $queue_super_users              = $htcondor::params::queue_super_users,
+  $queue_super_user_impersonate   = $htcondor::params::queue_super_user_impersonate,
   $use_anonymous_auth             = $htcondor::params::use_anonymous_auth,
   $use_fs_auth                    = $htcondor::params::use_fs_auth,
   $use_password_auth              = $htcondor::params::use_password_auth,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,6 +107,7 @@ class htcondor::params {
 
   # authentication
   $queue_super_users              = hiera_array('queue_super_users', [])
+  $queue_super_user_impersonate   = hiera('queue_super_user_impersonate', '')
   $use_anonymous_auth             = hiera('use_anonymous_auth', false)
   $use_fs_auth                    = hiera('use_fs_auth', true)
   $use_password_auth              = hiera('use_password_auth', true)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -106,6 +106,7 @@ class htcondor::params {
   $condor_gid                     = hiera('condor_gid', 0)
 
   # authentication
+  $queue_super_users              = hiera_array('queue_super_users', [])
   $use_anonymous_auth             = hiera('use_anonymous_auth', false)
   $use_fs_auth                    = hiera('use_fs_auth', true)
   $use_password_auth              = hiera('use_password_auth', true)

--- a/templates/10_security.config.erb
+++ b/templates/10_security.config.erb
@@ -73,6 +73,10 @@ ALLOW_CONFIG = root@$(FULL_HOSTNAME)
 ALLOW_NEGOTIATOR = $(CMS)
 ALLOW_NEGOTIATOR_SCHEDD = $(CMS)
 
+<% if ! @queue_super_users.empty? then -%>
+QUEUE_SUPER_USERS = <%= @queue_super_users.flatten.join(', ') %>
+<% end -%>
+
 # Don't allow nobody to run jobs
 SCHEDD.DENY_WRITE = nobody@$(UID_DOMAIN)
 # Authentication

--- a/templates/10_security.config.erb
+++ b/templates/10_security.config.erb
@@ -76,6 +76,9 @@ ALLOW_NEGOTIATOR_SCHEDD = $(CMS)
 <% if ! @queue_super_users.empty? then -%>
 QUEUE_SUPER_USERS = <%= @queue_super_users.flatten.join(', ') %>
 <% end -%>
+<% if ! @queue_super_user_impersonate.empty? then -%>
+QUEUE_SUPER_USER_MAY_IMPERSONATE = <%= @queue_super_user_impersonate %>
+<% end -%>
 
 # Don't allow nobody to run jobs
 SCHEDD.DENY_WRITE = nobody@$(UID_DOMAIN)


### PR DESCRIPTION
This adds knobs for `queue_super_users` and `queue_super_user_may_impersonate` (which is a string that may be a regexp matching user names). 

fixes #97