### PR TITLE
Add a "remote_submit" role

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ An HTCondor cluster consists of at least three types of nodes:
  * a scheduler for job submission
  * a collector/negotiator to match jobs with workers
 
-This puppet modules allows for the configuration of these three types of nodes.
+This puppet modules allows for the configuration of these three types of nodes plus a fourth one:
+ * a remote_submit, for local users to login and have a configured condor_submit
 
 
 ## Setup
@@ -57,6 +58,8 @@ If you wish to use a [pool password for authentication](http://research.cs.wisc.
  - settings for managers (nodes that run collector & negotiator daemons): `htcondor_manager.yaml`
  - settings for schedulers: `htcondor_scheduler.yaml`
  - settings for worker nodes: `htcondor_common.yaml`
+ - settings for remote submit nodes: `htcondor_remote_submit.yaml`
+
 The examples assume class management in hiere by adding  `hiera_include('classes')` to the `site.pp`.
 Real life examples can be found in https://github.com/uobdic/UKI-SOUTHGRID-BRIS-HEP.
 

--- a/examples/htcondor_remote_submit.yaml
+++ b/examples/htcondor_remote_submit.yaml
@@ -1,0 +1,5 @@
+---
+classes:
+  - htcondor
+
+htcondor::is_remote_submit: true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,6 +3,7 @@ class htcondor::config {
   $enable_multicore     = $htcondor::enable_multicore
   $ganglia_cluster_name = $htcondor::ganglia_cluster_name
   $is_scheduler         = $htcondor::is_scheduler
+  $is_remote_submit     = $htcondor::is_remote_submit
   $is_manager           = $htcondor::is_manager
   $is_worker            = $htcondor::is_worker
   $managers             = $htcondor::managers
@@ -41,6 +42,7 @@ class htcondor::config {
     $debug_msg = "constructing daemon list from \n \
                   -is_worker: ${is_worker}\n \
                   -is_scheduler: ${is_scheduler}\n \
+                  -is_remote_submit: ${is_remote_submit}\n \
                   -is_manager: ${is_manager}\n \
                   -enable_multicore: ${enable_multicore}\n \
                   -run_ganglia: ${run_ganglia} \n \
@@ -68,6 +70,11 @@ class htcondor::config {
   if $is_scheduler {
     class { 'htcondor::config::scheduler': }
     contain 'htcondor::config::scheduler'
+  }
+
+  if $is_remote_submit {
+    class { 'htcondor::config::remote_submit': }
+    contain 'htcondor::config::remote_submit'
   }
 
   if $is_manager {

--- a/manifests/config/remote_submit.pp
+++ b/manifests/config/remote_submit.pp
@@ -1,0 +1,15 @@
+# htcondor::config::remote_submit to configure passive nodes dedicated to user login and submission
+class htcondor::config::remote_submit{
+  $condor_user                = $htcondor::condor_user
+  $condor_group               = $htcondor::condor_group
+
+  include htcondor::config::security
+
+  file { '/etc/condor/config.d/19_remote_submit.config':
+    content => 'DAEMON_LIST = ""',
+    require => Package['condor'],
+    owner   => $condor_user,
+    group   => $condor_group,
+    mode    => '0644',
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,9 @@
 # [*$is_scheduler*]
 # If current machine is a condor scheduler
 #
+# [*$is_remote_submit*]
+# If current machine is a machine dedicated to submit jobs to a condor scheduler
+#
 # [*is_manager*]
 # If machine is a manager or a negotiator (condor term)
 #
@@ -137,6 +140,7 @@ class htcondor (
   $gpgkey                         = $htcondor::params::gpgkey,
   $dev_repositories               = $htcondor::params::dev_repositories,
   $is_scheduler                   = $htcondor::params::is_scheduler,
+  $is_remote_submit               = $htcondor::params::is_remote_submit,
   $is_manager                     = $htcondor::params::is_manager,
   $is_worker                      = $htcondor::params::is_worker,
   $machine_owner                  = $htcondor::params::machine_owner,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class htcondor::params {
 
   $is_manager                     = hiera('is_manager', false)
   $is_scheduler                   = hiera('is_scheduler', false)
+  $is_remote_submit               = hiera('is_remote_submit', false)
   $is_worker                      = hiera('is_worker', false)
 
   $cluster_has_multiple_domains   = hiera('cluster_has_multiple_domains', false)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,8 +2,11 @@
 #
 # Starts the services for HTCondor
 class htcondor::service {
+  $is_remote_submit = $htcondor::is_remote_submit
+
+  # Remote submit nodes don't have running service
   service { 'condor':
-    ensure     => running,
+    ensure     => $is_remote_submit ? { true => 'stopped', default => 'running' },
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
@@ -13,6 +16,8 @@ class htcondor::service {
   # service is not up. it's a RE-config command assuming something is already up.
   exec{ '/usr/sbin/condor_reconfig':
     refreshonly => true,
+    path   => '/usr/bin:/usr/sbin:/bin',
+    unless      => 'test -f /etc/condor/config.d/19_remote_submit.config',
     require     => Service['condor']
   }
 }


### PR DESCRIPTION
This PR defines a new type of node : **remote_submit**

The idea comes from this [DESY talk](https://agenda.hep.wisc.edu/event/1201/session/9/contribution/40/material/slides/0.pdf), slide 11: a remote submit allows you to:
* let your users login
* provide them a configured _condor_submit_ to submit jobs to a schedd, mentioned in conf (may be a personnal conf, _~/.condor/user_config_, see [this doc](https://htcondor-wiki.cs.wisc.edu/index.cgi/wiki?p=HowToLoadBalanceUsersToSubmitNodes))
* be able to get this host down (for software updates for example) seamlessly, so no downtime when a breach in the kernel has to be patched
* retrieve your files if you have a shared FS between schedd and remote_submit

So this PR implements a fourth type of node (after manager, scheduler,worker), called remote_submit (I'm interested if you have a better name to suggest!)
It has no running service and few configuration files, just enough to be able to authenticate a user so that he can pass _condor_submit_ and _condor_q_.