### PR TITLE
Add support for Debian repos and new versioned repo structure.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,6 +140,8 @@ class htcondor (
   $install_repositories           = $htcondor::params::install_repositories,
   $gpgcheck                       = $htcondor::params::gpgcheck,
   $gpgkey                         = $htcondor::params::gpgkey,
+  $condor_major_version           = $htcondor::params::condor_major_version,
+  $versioned_repositories         = $htcondor::params::versioned_repositories,
   $dev_repositories               = $htcondor::params::dev_repositories,
   $is_scheduler                   = $htcondor::params::is_scheduler,
   $is_remote_submit               = $htcondor::params::is_remote_submit,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,6 +68,8 @@ class htcondor::params {
   $install_repositories           = hiera('install_repositories', true)
   $gpgcheck                       = hiera('gpgcheck', true)
   $gpgkey                         = hiera('gpgkey', 'http://htcondor.org/yum/RPM-GPG-KEY-HTCondor')
+  $condor_major_version           = hiera('condor_major_version', '8.8')
+  $versioned_repos                = hiera('versioned_repos', false)
   $dev_repositories               = hiera('dev_repositories', false)
 
   $machine_owner                  = hiera('machine_owner', 'physics')

--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -2,6 +2,8 @@
 #
 # Provides yum repositories for HTCondor installation
 class htcondor::repositories {
+  $htcondor_major  = $htcondor::condor_major_version
+  $versioned_repos = $htcondor::versioned_repositories
   $dev_repos       = $htcondor::dev_repositories
   $gpgcheck        = $htcondor::gpgcheck
   $gpgkey          = $htcondor::gpgkey
@@ -22,9 +24,14 @@ class htcondor::repositories {
           before   => [Package['condor']],
         }
       } else {
+        if $versioned_repos {
+          $repo_url = "http://research.cs.wisc.edu/htcondor/yum/stable/${htcondor_major}/rhel\$releasever"
+        } else {
+          $repo_url = 'http://research.cs.wisc.edu/htcondor/yum/stable/rhel$releasever'
+        }
         yumrepo { 'htcondor-stable':
           descr    => "HTCondor Stable RPM Repository for Redhat Enterprise Linux ${facts['os']['release']['major']}",
-          baseurl  => 'http://research.cs.wisc.edu/htcondor/yum/stable/rhel$releasever',
+          baseurl  => $repo_url,
           enabled  => 1,
           gpgcheck => bool2num($gpgcheck),
           gpgkey   => $gpgkey,
@@ -35,8 +42,27 @@ class htcondor::repositories {
       }
     }
     'Debian'  : {
-      # http://research.cs.wisc.edu/htcondor/debian/
-      notify { 'Debian based systems currently not supported': }
+      $distro_name = downcase($facts['os']['name'])
+      $distro_code = $facts['os']['distro']['codename']
+      apt::source { 'htcondor':
+        allow_unsigned => false,
+        ensure         => present,
+        comment        => "HTCondor ${distro_name} ${distro_code} Repository",
+        location       => "http://research.cs.wisc.edu/htcondor/${distro_name}/${htcondor_major}/${distro_code}",
+        repos          => 'contrib',
+        release        => $distro_code,
+        architecture   => 'amd64',
+        key            => {
+          ensure => refreshed,
+          id     => '4B9D355DF3674E0E272D2E0A973FC7D2670079F6',
+          source => "http://research.cs.wisc.edu/htcondor/${distro_name}/HTCondor-Release.gpg.key",
+        },
+        include        => {
+          src    => false,
+          deb    => true,
+        },
+        notify_update  => true,
+      }
     }
     'Windows' : {
       # http://research.cs.wisc.edu/htcondor/manual/latest/3_2Installation.html#SECTION00425000000000000000

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,10 @@
     {
       "name": "puppet/selinux",
       "version_requirement": "> 1.0.0"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": "> 6.2.1"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This PR adds two features:
- Initial support for Debian and Ubuntu. Just adding the repositories is sufficient. We are using at least schedds on Ubuntu successfully. This adds `puppetlabs/apt` as a dependency. 
- Adapting to the new repository structure of HTCondor. 

HTCondor restructured their repositories with 8.8 from the old previous / stable / development to versioned subdirectories. This means updates are significantly less surprising as compared to the past workflow when `stable` contained `8.4` and was suddenly replaced by `8.6` over night. 

For backwards compatibility, the flag `versioned_repositories` is false by default, and the "old" repositories are still used. To accomodate the new URLs, `condor_major_version` (defaulting to `8.8` which is the first version in a versioned repository) can be set. 

Things are still a bit awkward upstream, i.e. `8.7` is not versioned yet, so `dev_repositories` still has some relevance. For Debian / Ubuntu, though, I only implemented the `versioned_repositories` and from the repository path, the notion of `stable` and `development` is gone there since that's essentially contained in `8.7` or `8.8`. 
