### PR TITLE
Move MASTER_NEW_BINARY_RESTART=PEACEFUL to condor_config.

### DIFF
--- a/templates/20_workernode.config.erb
+++ b/templates/20_workernode.config.erb
@@ -101,9 +101,6 @@ USE_PID_NAMESPACES = true
 USE_PID_NAMESPACES = false
 <% end -%>
 
-## If the binaries are updated, let any running jobs finish before restarting
-MASTER_NEW_BINARY_RESTART=PEACEFUL
-
 ## Logs
 MAX_MASTER_LOG = 104857600
 MAX_NUM_MASTER_LOG = 10

--- a/templates/condor_config.local.erb
+++ b/templates/condor_config.local.erb
@@ -46,3 +46,6 @@ SUBMIT_EXPRS = $(SUBMIT_EXPRS) AcctGroup, AcctSubGroup, AccountingGroup, Concurr
 CONDOR_DEVELOPERS = NONE
 CONDOR_DEVELOPERS_COLLECTOR = NONE
 <% end %>
+
+## If the binaries are updated, let any running jobs finish before restarting
+MASTER_NEW_BINARY_RESTART=PEACEFUL


### PR DESCRIPTION
If it is only set on the workernodes,
jobs will still be killed when the schedds are updated,
since they restart gracefully by default, killing
all shadows.