### PR TITLE
Allow to define start_always_users.

### DIFF
--- a/manifests/config/worker.pp
+++ b/manifests/config/worker.pp
@@ -17,6 +17,7 @@ class htcondor::config::worker {
   $htcondor_cgroup           = $htcondor::htcondor_cgroup
   $cgroup_memory_limit       = $htcondor::cgroup_memory_limit
   $enable_healthcheck        = $htcondor::enable_healthcheck
+  $start_always_users        = $htcondor::start_always_users
   $machine_owner             = $htcondor::machine_owner
   $memory_overcommit         = $htcondor::memory_overcommit
   $number_of_cpus            = $htcondor::number_of_cpus

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,6 +124,7 @@ class htcondor (
   $enable_condor_reporting        = $htcondor::params::enable_condor_reporting,
   $enable_cgroup                  = $htcondor::params::enable_cgroup,
   $enable_healthcheck             = $htcondor::params::enable_healthcheck,
+  $start_always_users             = $htcondor::params::start_always_users,
   $enable_multicore               = $htcondor::params::enable_multicore,
   $defrag_interval                 = $htcondor::params::defrag_interval,
   $defrag_draining_machines_per_hr = $htcondor::params::defrag_draining_machines_per_hr,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class htcondor::params {
   $enable_condor_reporting        = hiera('enable_condor_reporting', true)
   $enable_cgroup                  = hiera('enable_cgroup', false)
   $enable_healthcheck             = hiera('enable_healthcheck', false)
+  $start_always_users             = hiera_array('start_always_users', [])
   $enable_multicore               = hiera('enable_multicore', false)
   # defrag parameters
   $defrag_interval                 = hiera('defrag_interval',600)

--- a/templates/20_workernode.config.erb
+++ b/templates/20_workernode.config.erb
@@ -42,6 +42,10 @@ STARTD_CRON_WN_HEALTHCHECK_KILL = true
 
 ## When is this node willing to run jobs?
 START = (NODE_IS_HEALTHY =?= True) && (StartJobs =?= True)
+<% if ! @start_always_users.empty? then -%>
+## Some users can also run jobs if the node is not healthy / startjobs is false.
+START = ($(START)) || ( <%= @start_always_users.map { |s| "TARGET.Owner =?= \"#{s}\"" }.join(' || ') %> )
+<% end -%>
 <% else -%>
 START = TRUE
 <% end -%>


### PR DESCRIPTION
These users are always allowed to run jobs,
even on nodes which fail the health check or
for which startjobs is false.
This allows admins to mask production machines
for tests and use them exclusively.