### PR TITLE
Add dns_cache_refresh parameter.

### DIFF
--- a/manifests/config/common.pp
+++ b/manifests/config/common.pp
@@ -16,6 +16,7 @@ class htcondor::config::common {
 
   $leave_job_in_queue             = $htcondor::leave_job_in_queue
   $request_memory                 = $htcondor::request_memory
+  $dns_cache_refresh              = $htcondor::dns_cache_refresh
 
   $template_config_local          = $htcondor::template_config_local
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -228,6 +228,7 @@ class htcondor (
   $max_walltime                   = $htcondor::params::max_walltime,
   $max_cputime                    = $htcondor::params::max_cputime,
   $memory_factor                  = $htcondor::params::memory_factor,
+  $dns_cache_refresh              = $htcondor::params::dns_cache_refresh,
   $use_shared_port                = $htcondor::params::use_shared_port,
   $shared_port                    = $htcondor::params::shared_port,
   $shared_port_collector_name     = $htcondor::params::shared_port_collector_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,6 +92,7 @@ class htcondor::params {
   $max_walltime                   = hiera('max_walltime', '80 * 60 * 60')
   $max_cputime                    = hiera('max_cputime', '80 * 60 * 60')
   $memory_factor                  = hiera('memory_factor', '1000')
+  $dns_cache_refresh              = hiera('dns_cache_refresh', 28800+fqdn_rand(600, 'htcondor_dns_cache_refresh'))
 
   $ganglia_cluster_name           = hiera('ganglia_cluster_name', undef)
 

--- a/templates/condor_config.local.erb
+++ b/templates/condor_config.local.erb
@@ -41,6 +41,8 @@ SUBMIT_EXPRS = $(SUBMIT_EXPRS) AcctGroup, AcctSubGroup, AccountingGroup, Concurr
 
 <% end %>
 
+DNS_CACHE_REFRESH = <%= @dns_cache_refresh %>
+
 <% unless @enable_condor_reporting -%>
 # disable reports to condor-admin@cs.wisc.edu (http://research.cs.wisc.edu/htcondor/privacy.html)
 CONDOR_DEVELOPERS = NONE


### PR DESCRIPTION
Used to define the period when HTCondor requeries DNS
e.g. to resolve permissions of hosts.
Important since HTCondor also caches NXDOMAIN.
HTCondor default is 8 hours + a random offset of up to 10m
to avoid pounding of DNS servers,
which we mimic with fqdn_rand in puppet.