### PR TITLE
Add schedd_blocked_users and block message.

### DIFF
--- a/manifests/config/scheduler.pp
+++ b/manifests/config/scheduler.pp
@@ -17,6 +17,8 @@ class htcondor::config::scheduler {
   $remove_held_jobs_after     = $htcondor::remove_held_jobs_after
   # /etc/condor/config.d/21_schedd.config
   $daemon_list                = $htcondor::config::daemon_list
+  $schedd_blocked_users       = $htcondor::schedd_blocked_users
+  $schedd_blocked_user_msg    = $htcondor::schedd_blocked_user_msg
   # template files
   $template_ganglia           = $htcondor::template_ganglia
   $template_queues            = $htcondor::template_queues

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -206,6 +206,8 @@ class htcondor (
   $use_pid_namespaces             = $htcondor::params::use_pid_namespaces,
   $uses_connection_broker         = $htcondor::params::uses_connection_broker,
   $private_network_name           = $htcondor::params::private_network_name,
+  $schedd_blocked_users           = $htcondor::params::schedd_blocked_users,
+  $schedd_blocked_user_msg        = $htcondor::params::schedd_blocked_user_msg,
   $cert_map_file                  = $htcondor::params::cert_map_file,
   $cert_map_file_source           = $htcondor::params::cert_map_file_source,
   $krb_map_file                   = $htcondor::params::krb_map_file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -145,6 +145,10 @@ class htcondor::params {
   $uses_connection_broker         = hiera('uses_connection_broker', false)
   $private_network_name           = hiera('private_network_name', $::domain)
 
+  # Schedd configuration
+  $schedd_blocked_users           = hiera_array('schedd_blocked_users', [])
+  $schedd_blocked_user_msg        = hiera('schedd_blocked_user_msg', 'Submission is blocked for you, please contact cluster admins.')
+
   # SharedPort service configuration
   $use_shared_port                = hiera('use_shared_port', false)
   $shared_port                    = hiera('shared_port', 9618)

--- a/templates/21_schedd.config.erb
+++ b/templates/21_schedd.config.erb
@@ -50,3 +50,9 @@ MAX_NUM_MASTER_LOG = 10
 ##  This macro determines what daemons the condor_master will start and keep its watchful eyes on.
 ##  The list is a comma or space separated list of subsystem names
 DAEMON_LIST = <%= @daemon_list %>
+
+<% if ! @schedd_blocked_users.empty? then -%>
+SUBMIT_REQUIREMENT_NAMES = $(SUBMIT_REQUIREMENT_NAMES) NotBlockedUser
+SUBMIT_REQUIREMENT_NotBlockedUser = <%= @schedd_blocked_users.map { |s| "Owner != \"#{s}\"" }.join(' && ') %>
+SUBMIT_REQUIREMENT_NotBlockedUser_REASON = "<%= @schedd_blocked_user_msg %>"
+<% end -%>


### PR DESCRIPTION
Users listed in schedd_blocked_users will be disallowed
from submission and message provided via schedd_blocked_user_msg
will be shown.
Useful e.g. to temporarily block users to force them to contact
cluster admins.