### PR TITLE
Puppet 5 & Puppet 6 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,39 @@ script:
   - make test
 
 before_install:
-  - gem update bundler
+  - bundle -v
+  - rm -f Gemfile.lock
+  - gem update --system $RUBYGEMS_VERSION
+  - gem --version
+  - bundle -v
+
+stages:
+  - test
+  -
+    if: tag =~ ^v\d
+    name: deploy
 
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.0"
-  - rvm: 2.3.1
-    env: PUPPET_GEM_VERSION="~> 4.0"
-  allow_failures:
-  - rvm: 2.4.0
-    env: PUPPET_GEM_VERSION="~> 5.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 4.0"
+      stage: test
+    - rvm: 2.4.5
+      env: PUPPET_GEM_VERSION="~> 5.0"
+      stage: test
+    - env: PUPPET_GEM_VERSION="~> 6.0"
+      rvm: 2.5.3
+      stage: test
+    - env: DEPLOY_TO_FORGE=yes
+      stage: deploy
+
+branches:
+  only:
+    - master
+    - /^v\d/
+    - release
+    - development
 
 notifications:
   email: false
@@ -32,4 +51,4 @@ deploy:
     secure: "cF7HLnEO05rYFNukshMcw00tFudutpBqP2PF25ypbru1q+qmg/uNJp09k61wOaPYHwk/ZkpzDByGelJSPRoA04cEa/j+CshkrxfOwTzRLgEhy2FZUoBhHCDxMeQ5evG+GbzIu62Tpl9vuvxQBdIO072uF6DWEn6SjoqJQohifRk="
   on:
     tags: true
-    rvm: 2.4.0
+    condition: "$DEPLOY_TO_FORGE = yes"


### PR DESCRIPTION
 - removed older RVM versions ( < 2.3.X )
 - added Puppet 5 & 6 to test matrix