### PR TITLE
USERS customizable

### DIFF
--- a/manifests/config/security.pp
+++ b/manifests/config/security.pp
@@ -11,6 +11,7 @@ class htcondor::config::security (
   $condor_user                  = $htcondor::condor_user
   $condor_group                 = $htcondor::condor_group
   $pool_password_file           = $htcondor::pool_password
+  $users_list                   = $htcondor::users_list
 
   $schedulers                   = $htcondor::schedulers
   $managers                     = $htcondor::managers

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,6 +175,7 @@ class htcondor (
   $leave_job_in_queue             = $htcondor::params::leave_job_in_queue,
   $ganglia_cluster_name           = $htcondor::params::ganglia_cluster_name,
   $pool_password                  = $htcondor::params::pool_password_file,
+  $users_list                     = $htcondor::params::users_list,
   $uid_domain                     = $htcondor::params::uid_domain,
   $default_domain_name            = $htcondor::params::default_domain_name,
   $filesystem_domain              = $htcondor::params::filesystem_domain,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,10 @@
 # [*pool_password*]
 # Path to pool password file.
 #
+# [*users_list*]
+# customize the list of users in SCHEDD.ALLOW_WRITE
+# Default: *@$(UID_DOMAIN)
+#
 # [*uid_domain*]
 # Condor UID_DOMAIN
 # Default: example.com

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -144,6 +144,7 @@ class htcondor::params {
   )
   $pool_password_file             = hiera('pool_password_file', "puppet:///modules/${module_name}/pool_password"
   )
+  $users_list                     = hiera('users_list', '*@$(UID_DOMAIN)')
   $ssl_server_keyfile             = hiera('ssl_server_keyfile', '')
   $ssl_client_keyfile             = hiera('ssl_client_keyfile', '')
   $ssl_server_certfile            = hiera('ssl_server_certfile', '')

--- a/templates/10_security.config.erb
+++ b/templates/10_security.config.erb
@@ -33,7 +33,7 @@ WNS = \
 <%= @worker_list.sort.map { |k| "      #{k}" }.join(", \\\n") -%>
 <% end %>
 
-USERS = *@$(UID_DOMAIN)
+USERS = <%= @users_list %>
 
 # Clear out any old-style HOSTALLOW settings:
 HOSTALLOW_READ =


### PR DESCRIPTION
Very small change to make the USERS variable customizable in _/etc/condor/config.d/10_security.config_
The variable name may be modified if you don't fix it clear enough?