### PR TITLE
make sure not to backup the main config file

### DIFF
--- a/manifests/config/common.pp
+++ b/manifests/config/common.pp
@@ -24,7 +24,6 @@ class htcondor::config::common {
 
   # files common between machines
   file { '/etc/condor/config.d/00_config_local.config':
-    backup  => ".bak.${now}",
     content => template($template_config_local),
     require => Package['condor'],
     owner   => $condor_user,


### PR DESCRIPTION
Backing up the config.d files  leads to very unwanted behaviour.

Reason is that according to doc (https://htcondor.readthedocs.io/en/v8_8_5/admin-manual/introduction-to-configuration.html#ordered-evaluation-to-set-the-configuration) , all files within the config.d are parsed in a lexicographic order.

The issue therefore is : 

00_config_local.config
is lexicographically parsed before :
00_config_local.config.bak.123456
which is parsed before 
00_config_local.config.bak.456789

So : in case of any change inside the config_local.config files, and this happenned to us several times, the old configs actually do override the new configs, and things are not working as expected on condor_reconfig or condor_restart.

But worse : since the new .bak file is not managed, it is removed on subsequent puppet runs... and you are left with a running config that's not the equivalent of the config dir since the ".bak" file that caused issues disappeared, but was taken into account.

Additionnally, there is really no reason to backup files this way, the puppet filebuckets could help in case a previous version is really needed.