### PR TITLE
Adapt to changed HTCondor repository structure

### DIFF
--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -48,7 +48,7 @@ class htcondor::repositories {
         allow_unsigned => false,
         comment        => "HTCondor ${distro_name} Repository",
         location       => "https://research.cs.wisc.edu/htcondor/repo/${distro_name}/${htcondor_major}",
-        repos          => 'contrib',
+        repos          => 'main',
         release        => $distro_code,
         architecture   => 'amd64',
         key            => {

--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -25,7 +25,7 @@ class htcondor::repositories {
         }
       } else {
         if $versioned_repos {
-          $repo_url = "https://research.cs.wisc.edu/htcondor/yum/stable/${htcondor_major}/rhel\$releasever"
+          $repo_url = "https://research.cs.wisc.edu/htcondor/repo/${htcondor_major}/el\$releasever/release"
         } else {
           $repo_url = 'https://research.cs.wisc.edu/htcondor/yum/stable/rhel$releasever'
         }
@@ -43,12 +43,11 @@ class htcondor::repositories {
     }
     'Debian'  : {
       $distro_name = downcase($facts['os']['name'])
-      $distro_code = $facts['os']['distro']['codename']
       apt::source { 'htcondor':
         ensure         => present,
         allow_unsigned => false,
-        comment        => "HTCondor ${distro_name} ${distro_code} Repository",
-        location       => "https://research.cs.wisc.edu/htcondor/${distro_name}/${htcondor_major}/${distro_code}",
+        comment        => "HTCondor ${distro_name} Repository",
+        location       => "https://research.cs.wisc.edu/htcondor/repo/${distro_name}/${htcondor_major}",
         repos          => 'contrib',
         release        => $distro_code,
         architecture   => 'amd64',


### PR DESCRIPTION
@ccnifo @kreczko While this adapts to the apparently changed HTCondor repository layout (again — both yum and apt repos changed), I'd also like to ask your opinion on how to proceed on this. 

What this PR does: Adapt the `versioned_repos` case to use the new repo layout. 
* The new repo layout contains several 8.8 releases and many 8.9 releases, and new releases only seem to go there. 
* The non-`versioned_repos` contain the 8.6 series and older releases. 
* This PR drops the "intermediate" repository structure which contains most 8.8 releases (apart from newer ones) and some 8.9 releases (apart from newer ones). 

My thoughts when implementing things this way were:
* Supporting all three structures does not seem reasonable.
* The new layout contains what new users will want to use, and still contains several older 8.8 releases, so there seems no significant loss about dropping the "intermediate" layout. 
* The "non-versioned" case is likely still useful especially for 8.6 users. 
* I wanted to do things mostly non-breaking and allowing to toggle between versioned and non-versioned (to allow users to upgrade from 8.6 to 8.8). 

In the long run, my thoughts would be:
1. Deprecate and drop non-versioned repos (maybe some while after 8.10 arrives?). 
2. Deprecated and drop the current `dev_repositories` flag, since that can just be done by choosing `8.9` (or any other testing release) via the `condor_major_version` setting. We could drop that in parallel to dropping `versioned_repos`. 
3. Add support for the new `rc` and `daily` `yum` repositories, and their source / debug symbol variants. Seems they only exist for `yum`, though. 
4. Add control to choose between these (e.g. via an `Enum[]`). 

I think the last two points should only be addressed if the repository structure has really stabilized, though, right now it seems we are seeing a change every 1-2 years :-(. While this all develops in a good direction (e.g. no needlessly separate repos by Debian-based distro code-name, finally dropped the needless `stable` in the URL, offer explicit major version selection,...), too many changes are irritating. 

For reference, here's an example on how repos changed over time:

OS | older | old | new
-- | -- | -- | --
Ubuntu 18.04 | _we did not support apt yet_ | https://research.cs.wisc.edu/htcondor/ubuntu/8.8/bionic/ | https://research.cs.wisc.edu/htcondor/repo/ubuntu/8.8/
Debian Buster | _we did not support apt yet_ | https://research.cs.wisc.edu/htcondor/debian/8.8/buster/ | https://research.cs.wisc.edu/htcondor/repo/debian/8.8/
CentOS 7 | https://research.cs.wisc.edu/htcondor/yum/stable/rhel | https://research.cs.wisc.edu/htcondor/yum/stable/8.8/rhel7/ | https://research.cs.wisc.edu/htcondor/repo/8.8/el7/release/

Opinions welcome :-). 