### PR TITLE
repositories: Add back missing distro_code variable.

### DIFF
--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -43,6 +43,7 @@ class htcondor::repositories {
     }
     'Debian'  : {
       $distro_name = downcase($facts['os']['name'])
+      $distro_code = $facts['os']['distro']['codename']
       apt::source { 'htcondor':
         ensure         => present,
         allow_unsigned => false,


### PR DESCRIPTION
This was accidentally removed in 5a754e8fc612bcb64fae75d8e2110e8705012afb (by me :sob: )
since it is not used in the repository name anymore, but it is still used in the `apt::source` resource. 

Note this worked nevertheless, since this is a fallback used in `apt::source`. It still seems more concise to pass in a known-good value here for the HTCondor repository layout. 