### PR TITLE
Add knobs to overwrite `apt_key_id` and `apt_key_source`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,12 @@
 # [*gpgkey*]
 # URL of the GPG key used to sign the packages
 #
+# [*apt_key_id*]
+# ID of the GPG key used for apt repository
+#
+# [*apt_key_source*]
+# URL to the GPG key used for apt repository
+#
 # [*$is_scheduler*]
 # If current machine is a condor scheduler
 #
@@ -163,6 +169,8 @@ class htcondor (
   $install_repositories           = $htcondor::params::install_repositories,
   $gpgcheck                       = $htcondor::params::gpgcheck,
   $gpgkey                         = $htcondor::params::gpgkey,
+  $apt_key_id                     = $htcondor::params::apt_key_id,
+  $apt_key_source                 = $htcondor::params::apt_key_source,
   $condor_major_version           = $htcondor::params::condor_major_version,
   $versioned_repos                = $htcondor::params::versioned_repos,
   $dev_repositories               = $htcondor::params::dev_repositories,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,6 +79,8 @@ class htcondor::params {
   $install_repositories           = hiera('install_repositories', true)
   $gpgcheck                       = hiera('gpgcheck', true)
   $gpgkey                         = hiera('gpgkey', 'http://htcondor.org/yum/RPM-GPG-KEY-HTCondor')
+  $apt_key_id                     = hiera('apt_key_id', '4B9D355DF3674E0E272D2E0A973FC7D2670079F6')
+  $apt_key_source                 = hiera('apt_key_source', 'https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-Release.gpg.key')
   $condor_major_version           = hiera('condor_major_version', '8.8')
   $versioned_repos                = hiera('versioned_repos', false)
   $dev_repositories               = hiera('dev_repositories', false)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -78,7 +78,7 @@ class htcondor::params {
   false)
   $install_repositories           = hiera('install_repositories', true)
   $gpgcheck                       = hiera('gpgcheck', true)
-  $gpgkey                         = hiera('gpgkey', 'http://htcondor.org/yum/RPM-GPG-KEY-HTCondor')
+  $gpgkey                         = hiera('gpgkey', 'https://research.cs.wisc.edu/htcondor/repo/keys/RPM-GPG-KEY-HTCondor')
   $apt_key_id                     = hiera('apt_key_id', '4B9D355DF3674E0E272D2E0A973FC7D2670079F6')
   $apt_key_source                 = hiera('apt_key_source', 'https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-Release.gpg.key')
   $condor_major_version           = hiera('condor_major_version', '8.8')

--- a/manifests/repositories.pp
+++ b/manifests/repositories.pp
@@ -7,6 +7,8 @@ class htcondor::repositories {
   $dev_repos       = $htcondor::dev_repositories
   $gpgcheck        = $htcondor::gpgcheck
   $gpgkey          = $htcondor::gpgkey
+  $apt_key_id      = $htcondor::apt_key_id
+  $apt_key_source  = $htcondor::apt_key_source
   $condor_priority = $htcondor::condor_priority
   $major_release   = regsubst($::operatingsystemrelease, '^(\d+)\.\d+$', '\1')
 
@@ -54,8 +56,8 @@ class htcondor::repositories {
         architecture   => 'amd64',
         key            => {
           ensure => refreshed,
-          id     => '4B9D355DF3674E0E272D2E0A973FC7D2670079F6',
-          source => "https://research.cs.wisc.edu/htcondor/${distro_name}/HTCondor-Release.gpg.key",
+          id     => $apt_key_id,
+          source => $apt_key_source,
         },
         include        => {
           src => false,


### PR DESCRIPTION
This matches the support we have for `gpgkey` which affects the RPM repositories. 

Since HTCondor upstream has (again) changed repository structure and is now also using different signing keys for each variant:
https://research.cs.wisc.edu/htcondor/repo/keys/
it seems reasonable to be more flexible here, to allow consumers of the module to react to upstream's changes faster and potentially also to simplify rolling out their own repository mirrors. 

For reference, I am using code as follows locally, to support the current `9.0`, `9.1` and previous versions:
```
if ($facts['os']['family'] == 'Debian') {
  if (versioncmp($htcondor_version, '9.0') == -1) {
    # Older than 9.0, use old GPG key.
    $_apt_key_source = 'https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-Release.gpg.key'
    $_apt_key_id = '4B9D355DF3674E0E272D2E0A973FC7D2670079F6'
  } elsif (versioncmp($htcondor_version, '9.0') == 0) {
    # Exactly 9.0 (LTS), use 9.0 GPG key.
    $_apt_key_source = 'https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-9.0-Key'
    $_apt_key_id = 'C0082877C6B6B74A6846786806701040748E8328'
  } else {
    # Newer than 9.0, use 9.1 GPG key (used by feature releases).
    $_apt_key_source = 'https://research.cs.wisc.edu/htcondor/repo/keys/HTCondor-9.1-Key'
    $_apt_key_id = 'FB7457AA32CCA224CBDCA6D76EA32EB86D4CA7CD'
  }
} elsif $facts['os']['family'] == 'RedHat' {
  if (versioncmp($htcondor_version, '9.0') == -1) {
    # Older than 9.0, use old GPG key.
    $_gpgkey = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-HTCondor'
   } elsif (versioncmp($htcondor_version, '9.0') == 0) {
    # Exactly 9.0 (LTS), use 9.0 GPG key.
    $_gpgkey = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-HTCondor-9.0'
  } else {
    # Newer than 9.0, use 9.1 GPG key (used by feature releases).
    $_gpgkey = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-HTCondor-9.1'
  }
}
```
We deploy the RPM GPG keys separately to our nodes. 

I'm not sure it is reasonable to really integrate this kind of logic in the module, since:
-  It does not cover all variants (e.g. there are also daily builds).
-  Given history, things may change again with HTCondor `10.x`. At least, new signing keys seem very likely. 
- The module logic currently allows to specify version and keys separately, so this would have to be decoupled somehow (e.g. `undef` key could mean "choose automatically"). 

So for now, I kept the PR minimal, only adding the necessary flexibility to configure this from "outside". Other ideas welcome (or maybe left for other PRs?). 

