### PR TITLE
[RFC] CI: Add basic GitHub actions CI. 

### DIFF
--- a/.github/workflows/rake_checks.yml
+++ b/.github/workflows/rake_checks.yml
@@ -1,0 +1,66 @@
+name: Run rake tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rake-static:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        checks:
+          - check:symlinks
+          - check:git_ignore
+          - check:dot_underscore
+          - check:test_file
+          - rubocop
+          - syntax
+          - lint
+          - metadata_lint
+          - parallel_spec
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare bundle
+        run: |
+          sudo apt install bundler
+          bundle -v
+          rm -f Gemfile.lock
+          bundle install --path=~/test_bundle
+          bundle config set without 'system_tests'
+
+      - name: Run checks
+        run: |
+          bundle exec rake ${{ matrix.checks }}
+
+  rake-spec:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        puppet_version:
+          - "~> 6.0"
+          - "~> 7.0"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Prepare bundle
+        env:
+          PUPPET_GEM_VERSION: ${{ matrix.puppet_version }}
+        run: |
+          sudo apt install bundler
+          bundle -v
+          rm -f Gemfile.lock
+          bundle install --path=~/test_bundle
+          bundle config set without 'system_tests'
+
+      - name: Run spec tests
+        run: |
+          bundle exec rake parallel_spec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,10 @@
 ---
-require: rubocop-rspec
+require:
+ - rubocop-rspec
+ - rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.7'
   Include:
   - "./**/*.rb"
   Exclude:
@@ -16,10 +18,10 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText/DecorateString:
+I18n/GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
   - spec/*
@@ -63,7 +65,11 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Description: Prefer always trailing comma on multiline literals. This makes diffs,
+    and re-ordering nicer.
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInHashLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
@@ -86,7 +92,7 @@ Style/StringMethods:
   Enabled: true
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development do
   gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                               require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem 'rubocop-i18n',                                  require: false
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]


### PR DESCRIPTION
Since Travis CI is mostly dead, I was wondering whether we'd want to move to GitHub actions, which has become quite mature in the last years. 

This PR prepared the basics, carrying over most tests the Travis CI has done, and they seem to work. Another approach, though, would be to migrate "all the things PDK" and then go for something such as https://github.com/puppets-epic-show-theatre/action-pdk-validate . 

Comments / ideas / suggestions? 